### PR TITLE
♻️ 重构：模块化CPU模拟器实现并优化构建配置

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,31 +2,45 @@
 cmake_minimum_required(VERSION 3.15)
 
 # 📦 定义项目基本信息：名称 remu，版本 0.1.0
-project(remu VERSION 0.1.0)
+# VERSION关键字允许通过${PROJECT_VERSION}等变量访问版本信息
+project(remu VERSION 0.1.0 LANGUAGES CXX)
 
 # 🎯 强制要求使用 C++23 标准（需编译器支持）
 set(CMAKE_CXX_STANDARD 23)
+
 # 🔒 明确声明必须满足上述 C++ 标准要求（否则构建失败）
+# 如果编译器不支持C++23，将直接报错而不是降级使用
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# 📚 添加项目的头文件目录
+# PROJECT_SOURCE_DIR指向项目根目录的绝对路径
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
 # 📂 添加源代码目录（核心实现存放在 src 目录）
+# 该目录下需要有独立的CMakeLists.txt文件
 add_subdirectory(src)
 
 # 🧪 添加测试代码目录（测试用例存放在 tests 目录）
 add_subdirectory(tests)
 
 # ✅ 启用项目的测试功能（需配合 ctest 命令使用）
+# 启用后可使用"ctest"命令运行测试
 enable_testing()
 
 # -------------------------------------------------------------------
 # ✨ 推荐扩展功能（可根据需要取消注释使用）：
 # 
 # 1. 编译器警告强化：
+# -Wall: 启用所有常见警告
+# -Wextra: 启用额外的警告检查
+# -pedantic: 严格遵守语言标准
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
 #
 # 2. 调试符号生成：
+# Debug模式会生成调试符号，方便使用GDB等工具调试
 # set(CMAKE_BUILD_TYPE Debug)
 #
 # 3. 添加编译特性检查：
+# 确保目标支持C++23特性
 # target_compile_features(remu PRIVATE cxx_std_23)
 # -------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,8 @@
 # 🏷️ 第一个参数 remu 是目标名称（最终生成的可执行文件名）
 # 📄 后续参数是构建所需的源文件列表（这里只有一个 main.cpp）
 # 🌈 完整语法：add_executable(<name> [WIN32] [MACOSX_BUNDLE] [EXCLUDE_FROM_ALL] [source1] [source2 ...])
-add_executable(remu main.cpp)  # 👷♂️ 构建引擎会执行以下操作：
+add_executable(remu main.cpp 
+                    cpu.cpp)   # 👷♂️ 构建引擎会执行以下操作：
                                # 1️⃣ 编译 main.cpp -> main.obj（Windows）或 main.o（Unix）
                                # 2️⃣ 链接生成 remu.exe（Windows）或 remu（Unix）
                                # 🚀 后续可用 target_link_libraries 添加库依赖

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,118 +1,16 @@
-#include <array>
-#include <cstdint>
 #include <iostream>
-#include <vector>
 
-// 🖥️ CPU模拟器结构体：模拟RISC架构处理器核心组件
-struct Cpu {
-  std::array<uint64_t, 32> regs{};  // 🧠 32个通用寄存器（x0-x31）
-  uint64_t pc = 0;                  // 📍 程序计数器
-  std::vector<uint8_t> mem;         // 💾 模拟内存
-
-  // 🏗️ 构造函数：用程序代码初始化CPU
-  Cpu(const std::vector<uint8_t>& code) : mem(code) {
-    // 🚀 初始化寄存器状态
-    regs[2] = mem.size() - 8;  // 📌 栈指针8字节对齐（x2寄存器）
-    regs[0] = 0;               // 🔒 硬编码x0寄存器为0
-  }
-
-  // 🚀 取指：从内存中读取当前指令
-  uint32_t fetch() {
-    // ⚠️ 简单内存访问（实际需要边界检查）
-    return *(uint32_t*)(&mem[pc]);
-  }
-
-  // 🎯 执行指令的核心方法
-  void execute(uint32_t instr) {
-    // 🔍 解析指令字段
-    uint8_t opcode = instr & 0x7F;       // 🎛️ 操作码（低7位）
-    uint8_t rd = (instr >> 7) & 0x1F;    // 📥 目标寄存器编号
-    uint8_t rs1 = (instr >> 15) & 0x1F;  // 📤 源寄存器1编号
-    int64_t imm =
-        (int64_t)(int32_t)(instr & 0xFFF00000) >> 20;  // 📡 符号扩展立即数
-
-    // 🛠️ ADDI指令处理（I-type）
-    if (opcode == 0x13) {          // 🔖 操作码0x13对应ADDI
-      regs[rd] = regs[rs1] + imm;  // ➕ 执行加法操作
-    }
-
-    pc += 4;      // ⏩ 默认指令步长（RISC-V为32位定长）
-    regs[0] = 0;  // 🔐 强制归零寄存器保持为0
-  }
-
-  // 📊 调试输出：显示关键寄存器状态
-  void debug() {
-    std::cout << "PC: 0x" << std::hex << pc << " | x1: 0x" << regs[1]
-              << " | x2(sp): 0x" << regs[2] << std::endl;
-  }
-};
+#include "cpu.h"
 
 int main() {
-  // 📦 示例程序：ADDI x1, x0, 0x42
-  // 🔧 机器码：0x04200093（小端存储）
-  std::vector<uint8_t> code(1024);
-  code[0] = 0x93;  // 🌀 最低字节（0x93）
-  code[1] = 0x00;  // 🌀 funct3和寄存器部分
-  code[2] = 0x20;  // 🌀 立即数低位
-  code[3] = 0x04;  // 🌀 立即数高位（小端存储）
+  // 📦 初始化模拟器
+  std::vector<uint8_t> program(1024);  // 初始化1KB的程序内存
+  Cpu cpu(program);
 
-  // 🔌 初始化CPU实例
-  Cpu cpu(code);
+  // 🚀 启动模拟器
+  std::cout << "RISC-V Simulator Starting..." << std::endl;
 
-  // 🎮 模拟器运行周期
-  // 🔄 取指-执行循环（此处简化为单步执行）
-  uint32_t instr = cpu.fetch();
-  cpu.execute(instr);
+  // TODO: 在这里添加实际的程序加载和执行逻辑
 
-  // 📝 验证执行结果
-  cpu.debug();  // ✅ 预期输出：x1 = 0x42
-
-  // ======================
-  // 🧪 自动化验证代码
-  // ======================
-  std::cout << "\n=== 🔍 Result Validation ===" << std::endl;
-  bool all_pass = true;
-
-  // 🔄 验证点1：x1寄存器值
-  const uint64_t expected_x1 = 0x42;
-  if (cpu.regs[1] == expected_x1) {
-    std::cout << "✅ x1 register check passed (0x" << std::hex << expected_x1
-              << ")" << std::endl;
-  } else {
-    std::cout << "❌ x1 register mismatch | Expected: 0x" << expected_x1
-              << " | Actual: 0x" << cpu.regs[1] << std::endl;
-    all_pass = false;
-  }
-
-  // 🔄 验证点2：程序计数器PC
-  const uint64_t expected_pc = 0x4;
-  if (cpu.pc == expected_pc) {
-    std::cout << "✅ PC check passed (0x" << expected_pc << ")" << std::endl;
-  } else {
-    std::cout << "❌ PC mismatch | Expected: 0x" << expected_pc
-              << " | Actual: 0x" << cpu.pc << std::endl;
-    all_pass = false;
-  }
-
-  // 🔄 验证点3：栈指针x2
-  const uint64_t expected_sp = 0x3f8;  // 1024-8=1016=0x3F8
-  if (cpu.regs[2] == expected_sp) {
-    std::cout << "✅ Stack pointer check passed (0x" << expected_sp << ")"
-              << std::endl;
-  } else {
-    std::cout << "❌ Stack pointer mismatch | Expected: 0x" << expected_sp
-              << " | Actual: 0x" << cpu.regs[2] << std::endl;
-    all_pass = false;
-  }
-
-  // 🏁 最终测试结果
-  std::cout << "\nTest Result: ";
-  if (all_pass) {
-    std::cout << "🎉 All checks passed!";
-  } else {
-    std::cout << "⚠️ Some checks failed!";
-  }
-  std::cout << std::endl;
-
-  return all_pass ? 0 : 1;
+  return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,12 @@
-add_executable(test_runner test_main.cpp)
+# 🧩 创建可执行测试程序  
+add_executable(test_runner  
+    test_main.cpp      # 🧪 测试主入口（测试逻辑载体）  
+    ../src/cpu.cpp     # 🖥️ 被测CPU模块源码（需验证的核心功能）  
+)  
+
+# 🌐 添加头文件搜索路径  
+target_include_directories(test_runner  
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include  # 👉 使用 include 目录
+        ${CMAKE_SOURCE_DIR}/src      # 👉 私有头文件可以保留在 src
+)


### PR DESCRIPTION
- 将CPU核心逻辑从main.cpp拆分至独立cpu.cpp/cpu.h文件
- 在CMake中显式声明C++语言标准及头文件包含路径
- 更新测试框架CMake配置以正确链接CPU模块源码
- 清理main.cpp中的冗余代码，保留模拟器启动框架
- 补充相关CMake脚本的注释说明及编译选项建议